### PR TITLE
Fixed bugs in message routes and created aliases for message-user relationships

### DIFF
--- a/controllers/api/user-routes.js
+++ b/controllers/api/user-routes.js
@@ -22,7 +22,7 @@ router.get("/", async (req, res) => {
 
     // Checks if there are any users
     if (!userData) {
-      res.status(404).json({ message: "No users exist" });
+      res.status(404).json({ message: "No users found" });
       return;
     }
     res.status(200).json(userData);

--- a/models/index.js
+++ b/models/index.js
@@ -23,11 +23,13 @@ TBLScript.belongsTo(TBLUser, {
 
 TBLMessages.belongsTo(TBLUser, {
   foreignKey: "receiverID",
+  as: "receiver",
   onDelete: "SET NULL",
 });
 
 TBLMessages.belongsTo(TBLUser, {
   foreignKey: "senderID",
+  as: "sender",
   onDelete: "SET NULL",
 });
 


### PR DESCRIPTION
- Previously the GET /users route was only looking for users that the requesting user has sent messages (not received). However, we also want to populate the message board with people the requesting user has received messages from but not replied to
- Previously the GET /user/chat route was only finding messages that the requesting user sent (not received). However, we also want to populate the chat with messages the requesting user received.
- The messages model has 2 foreign keys in the user model, so we need to add aliases to differentiate which foreign key we want to include in the controller route
- Added aliases that allow us to show the sender and receiver of messages