### PR TITLE
Add hooks to convert user's name to lowercase & converted the clients search terms to lowercase to prevent mismatches due to capitalization

### DIFF
--- a/controllers/api/script-routes.js
+++ b/controllers/api/script-routes.js
@@ -45,7 +45,7 @@ router.get("/:id", async (req, res) => {
 router.get("/author/:name", async (req, res) => {
   try {
     // Get the search term from the URL parameter and remove any whitespace
-    const searchName = req.params.name.replace(/\s/g, "");
+    const searchName = req.params.name.replace(/\s/g, "").toLowerCase();
 
     // Find the role with the title "writer" in the TBLRole table
     const role = await TBLRole.findOne({
@@ -68,7 +68,9 @@ router.get("/author/:name", async (req, res) => {
     // Loop through all the writers
     for (const author of authorData) {
       // Combine the first and last names of the author's record into one string, removing any whitespace
-      const authorName = (author.firstName + author.lastName).replace(/\s/g,"");
+      const authorName = (author.firstName + author.lastName)
+        .replace(/\s/g, "")
+        .toLowerCase();
 
       // Check if the clinet's search term is included in the combined first and last name of the author's record
       if (authorName.includes(searchName)) {

--- a/models/TBLUser.js
+++ b/models/TBLUser.js
@@ -79,9 +79,13 @@ TBLUser.init(
     hooks: {
       beforeCreate: async (newUserData) => {
         newUserData.password = await bcrypt.hash(newUserData.password, 10);
+        newUserData.firstName = newUserData.firstName.toLowerCase();
+        newUserData.lastName = newUserData.lastName.toLowerCase();
         return newUserData;
       },
       beforeUpdate: async (updatedUserData) => {
+        updatedUserData.firstName = updatedUserData.firstName.toLowerCase();
+        updatedUserData.lastName = updatedUserData.lastName.toLowerCase();
         if (updatedUserData.password) {
           updatedUserData.password = await bcrypt.hash(updatedUserData.password, 10);
         }


### PR DESCRIPTION
- Added beforeCreate and beforeUpdate hooks to convert firstName and lastName fields to lowercase before saving entries to the database
- The hooks will improve data integrity by ensuring that all user names are saved to the database in the same format (lowercase) regardless of how the user entered their name
- Added .toLowerCase() to the client's search name in the GET Route for searching authors to ensure consistency and prevent mismatches due to capitalization
- Added .toLowerCase() to the authorName string in the GET Route as an extra safety measure on top of the hooks